### PR TITLE
Implement and test full model JSON saving/loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 install:
     - pip install -U pytest
     - pip install .
-    - pip install git+https://github.com/sbrg/ecolime.git@devel
+    - pip install git+https://github.com/sbrg/ecolime.git
 
 script: travis_wait pytest
 

--- a/cobrame/core/MEReactions.py
+++ b/cobrame/core/MEReactions.py
@@ -57,7 +57,7 @@ class MEReaction(Reaction):
                 for enzyme in modification.enzyme:
                     stoichiometry[enzyme] -= \
                         mu / modification.keff / 3600. * scale * abs(count)
-            elif type(modification.enzyme) == str:
+            elif isinstance(modification.enzyme, string_types):
                 stoichiometry[modification.enzyme] -= \
                     mu / modification.keff / 3600. * scale * abs(count)
 
@@ -91,7 +91,7 @@ class MEReaction(Reaction):
                 for enzyme in subreaction_data.enzyme:
                     stoichiometry[enzyme] -= mu / subreaction_data.keff / \
                                              3600. * count
-            elif type(subreaction_data.enzyme) == str:
+            elif isinstance(subreaction_data.enzyme, string_types):
                 stoichiometry[subreaction_data.enzyme] -= \
                     mu / subreaction_data.keff / 3600. * count
 

--- a/cobrame/io/JSONSCHEMA
+++ b/cobrame/io/JSONSCHEMA
@@ -1,0 +1,590 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "COBRAme",
+    "description": "JSON representation of COBRA ME-model",
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "version": {
+            "type": "integer",
+            "default": 1
+        },
+        "notes": {"type": "object"},
+        "annotation": {"type": "object"},
+
+        "global_info": {
+            "type": "object",
+            "required": ["kt", "r0", "k_deg", "m_rr", "m_aa", "f_rRNA", "m_nt",
+                         "f_mRNA", "m_tRNA", "f_tRNA"],
+            "properties": {
+                "kt": {"type": "number"},
+                "r0": {"type": "number"},
+                "k_deg": {"type": "number"},
+                "m_rr": {"type": "number"},
+                "m_aa": {"type": "number"},
+                "f_rRNA": {"type": "number"},
+                "m_nt": {"type": "number"},
+                "f_mRNA": {"type": "number"},
+                "m_tRNA": {"type": "number"},
+                "f_tRNA": {"type": "number"},
+                "RNA_polymerase": {"type": "array"},
+                "translation_terminators": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {"type": "string"}
+                    }
+                },
+                "met_start_codons": {"type": "array"},
+                "peptide_processing_subreactions": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {"type": "number"}
+
+                    }
+                },
+                "translation_elongation_subreactions": {"type": "array"},
+                "translation_start_subreactions": {"type": "array"},
+                "translocation_multipliers": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {"type": "object"}
+                    }
+                },
+                "temperature": {"type": "number"},
+                "propensity_scaling": {"type": "number"},
+                "GC_fraction": {"type": "number"},
+                "modification_formula": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "object",
+                            "properties": {
+                                "formula": {"type": "string"}
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+
+            }
+        },
+
+        "stoichiometric_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "_stoichiometry": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "lower_bound": {"type": "number"},
+                    "upper_bound": {"type": "number"},
+                    "subreactions": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    }
+                }
+            }
+        },
+        "complex_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "stoichiometry": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "modifications": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "complex_id": {"type": ["string", "null"]}
+                }
+            }
+        },
+        "transcription_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "modifications": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "subreactions": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "nucleotide_sequence": {"type": "string"},
+                    "RNA_products": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "RNA_polymerase": {"type": "string"},
+                    "rho_dependent": {
+                        "type": "boolean",
+                        "default": "false"
+                    }
+                }
+            }
+        },
+        "translation_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "modifications": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "subreactions": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "nucleotide_sequence": {"type": "string"},
+                    "mRNA": {"type": "string"},
+                    "protein": {"type": "string"}
+
+                }
+            }
+        },
+        "tRNA_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "modifications": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "codon": {"type": "string"},
+                    "RNA": {"type": "string"},
+                    "amino_acid": {"type": "string"},
+                    "synthetase": {
+                        "type": ["string", "null"],
+                        "default": "null"
+                    },
+                    "synthetase_keff": {"type": "number"}
+                }
+            }
+        },
+        "translocation_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "enzyme_dict": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {
+                                "type": "object",
+                                "properties": {
+                                    "length_dependent": {"type": "boolean"},
+                                    "fixed_keff": {"type": "boolean"}
+                                }
+                            }
+                        }
+                    },
+                    "stoichiometry": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "keff": {"type": "number"},
+                    "length_dependent_energy": {"type": "boolean"}
+                }
+            }
+        },
+        "posttranslation_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "processed_protein_id": {"type": "string"},
+                    "unprocessed_protein_id": {"type": "string"},
+                    "propensity_scaling": {"type": "number"},
+                    "aggregation_propensity": {"type": "number"},
+                    "translocation": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "modifications": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "subreactions": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "surface_area": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "keq_folding": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "k_folding": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    }
+                }
+            }
+        },
+        "modification_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "stoichiometry": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "enzyme": {
+                        "type": ["string", "null", "array"],
+                        "default": "null"
+                    },
+                    "keff": {"type": "number"}
+                }
+            }
+        },
+        "subreaction_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "stoichiometry": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": "number"}
+                        }
+                    },
+                    "enzyme": {
+                        "type": ["string", "null", "array"],
+                        "default": "null"
+                    },
+                    "keff": {"type": "number"}
+                }
+            }
+        },
+        "generic_data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "component_list": {"type": "array"}
+                }
+            }
+        },
+        "reactions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "metabolites": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {"type": ["string", "number"]}
+                        }
+                    },
+                    "reaction_type": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "required": ["MetabolicReaction"],
+                                "properties": {
+                                    "MetabolicReaction": {
+                                        "type": "object",
+                                        "properties": {
+                                            "complex_data": {"type": ["string", "null"]},
+                                            "stoichiometric_data": {"type": "string"},
+                                            "keff": {"type": "number"},
+                                            "reverse": {"type": "boolean"}
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["ComplexFormation"],
+                                "properties": {
+                                    "ComplexFormation": {
+                                        "type": "object",
+                                        "properties": {
+                                            "_complex_id": {"type": "string"},
+                                            "complex_data_id": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["PostTranslationReaction"],
+                                "properties": {
+                                    "PostTranslationReaction": {
+                                        "type": "object",
+                                        "properties": {
+                                            "posttranslation_data": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["TranscriptionReaction"],
+                                "properties": {
+                                    "TranscriptionReaction": {
+                                        "type": "object",
+                                        "properties": {
+                                            "transcription_data": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["GenericFormationReaction"],
+                                "properties": {
+                                    "GenericFormationReaction": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["Reaction"],
+                                "properties": {
+                                    "Reaction": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["SummaryVariable"],
+                                "properties": {
+                                    "SummaryVariable": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["TranslationReaction"],
+                                "properties": {
+                                    "TranslationReaction": {
+                                        "type": "object",
+                                        "properties": {
+                                            "translation_data": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["tRNAChargingReaction"],
+                                "properties": {
+                                    "tRNAChargingReaction": {
+                                        "type": "object",
+                                        "properties": {
+                                            "tRNA_data": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            }
+
+                        ],
+                        "lower_bound": {"type": "number"},
+                        "upper_bound": {"type": "number"},
+                        "objective_coefficient": {
+                            "type": "number",
+                            "default": 0
+                        },
+                        "variable_kind": {
+                            "type": "string",
+                            "pattern": "continuous",
+                            "default": "continuous"
+                        }
+                    }
+                }
+            }
+        },
+        "metabolites": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "compartment": {
+                        "type": "string",
+                        "pattern": "[a-z]{1,2}"
+                    },
+                    "charge": {"type": "integer"},
+                    "formula": {"type": ["string", "null"]},
+                    "_bound": {
+                        "type": "number",
+                        "default": 0
+                    },
+                    "_constraint_sense": {
+                        "type": "string",
+                        "default": "E",
+                        "pattern": "E|L|G"
+                    },
+                    "notes": {"type": "object"},
+                    "annotation": {"type": "object"},
+                    "metabolite_type": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "required": ["Metabolite"],
+                                "properties": {
+                                    "Metabolite": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["TranslatedGene"],
+                                "properties": {
+                                    "TranslatedGene": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["ProcessedProtein"],
+                                "properties": {
+                                    "ProcessedProtein": {
+                                        "type": "object",
+                                        "required": ["unprocessed_protein_id"],
+                                        "properties": {
+                                            "unprocessed_protein_id": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["Complex"],
+                                "properties": {
+                                    "Complex": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["Ribosome"],
+                                "properties": {
+                                    "Ribosome": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["GenericComponent"],
+                                "properties": {
+                                    "GenericComponent": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["GenerictRNA"],
+                                "properties": {
+                                    "GenerictRNA": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["RNAP"],
+                                "properties": {
+                                    "RNAP": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["Constraint"],
+                                "properties": {
+                                    "Constraint": {"type": "object"}
+                                 }
+                            },
+                            {
+                                "type": "object",
+                                "required": ["TranscribedGene"],
+                                "properties": {
+                                    "TranscribedGene": {
+                                        "type": "object",
+                                        "required": ["nucleotide_sequence",
+                                                     "right_pos", "left_pos",
+                                                     "strand", "RNA_type"],
+                                        "properties": {
+                                            "nucleotide_sequence": {"type": "string"},
+                                            "left_pos": {"type": "number"},
+                                            "right_pos": {"type": "number"},
+                                            "strand": {
+                                                "type": "string",
+                                                "pattern": "[+]|[-]"
+                                            },
+                                            "RNA_type": {
+                                                "type": "string",
+                                                "pattern": "mRNA|rRNA|tRNA|ncRNA"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cobrame/io/jsonme.py
+++ b/cobrame/io/jsonme.py
@@ -1,18 +1,38 @@
 import copy
+import json
+from warnings import warn
+import os
+
+from sympy import Basic, sympify, Symbol
+from numpy import bool_, float_
+from six import iteritems, string_types
+from jsonschema import validate, ValidationError
 
 from cobra.io.json import save_json_model, load_json_model
-from sympy import Basic, sympify, Symbol
+import cobrame
 from cobrame import mu
 
 mu_temp = Symbol('mu')
 
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
 def save_json_me(me0, file_name, pretty=False):
     """
-    Save ME model as json
+    Save a stripped-down JSON version of the ME-model. This will exclude all of
+    ME-Model information except the reaction stoichiometry information and the
+    reaction bounds. Saving/loading a model in this format will thus occur much
+    quicker, but limit the ability to edit the model and use most of its
+    features.
 
-    model : :class:`~cobrame.core.MEModel.MEmodel` object
+    :param :class:`~cobrame.core.MEModel.MEModel` model:
+        A full ME-model
 
-    file_name : str or file-like object
+    :param str or file-like object file_name:
+        Filename of the JSON output
+
+    :returns JSON-object:
+        Stripped-down JSON representation of full ME-model
     """
     me = copy.deepcopy(me0)
 
@@ -44,18 +64,28 @@ def get_sympy_expression(value):
     expression_value = sympify(value)
     return expression_value.subs(mu_temp, mu)
 
+
 def load_json_me(file_name):
     """
-    Load ME model from json
+    Load a stripped-down JSON version of the ME-model. This will exclude all of
+    ME-Model information except the reaction stoichiometry information and the
+    reaction bounds. Saving/loading a model in this format will thus occur much
+    quicker, but limit the ability to edit the model and use most of its
+    features.
 
-    file_name : str or file-like object
+    :param str or file-like object file_name:
+        Filename of the JSON ME-model
+
+    :returns COBRA Model object:
+        COBRA Model representation of the full ME-model. This will not include
+        all of the functionality of a :class:`~cobrame.core.MEModel.MEModel`
     """
     me = load_json_model(file_name)
 
     # Re-convert stoichiometries back to sympy
     for rxn in me.reactions:
         for met in rxn.metabolites:
-            s =rxn._metabolites[met]
+            s = rxn._metabolites[met]
             try:
                 rxn._metabolites[met] = float(s)
             except ValueError:
@@ -78,9 +108,463 @@ def load_json_me(file_name):
 
     return me
 
+# -----------------------------------------------------------------------------
+# Functions below here facilitate json dumping/loading of full ME-models with
+# all process_data/reaction info intact.
+_REQUIRED_REACTION_ATTRIBUTES = {"id", "name", "metabolites", "lower_bound",
+                                 "upper_bound", "objective_coefficient",
+                                 "variable_kind"}
 
-"""
-Add ME objects to the cobrapy json-schema
-Particularly, translation_data, etc.
-"""
-#json_schema
+# Reaction types can have different attributes
+_REACTION_TYPE_DEPENDENCIES = \
+    {'MetabolicReaction': ['complex_data',
+                           'stoichiometric_data',
+                           'keff', 'reverse'],
+     'ComplexFormation': ['_complex_id',
+                          'complex_data_id'],
+     'PostTranslationReaction':
+         ['posttranslation_data'],
+     'TranscriptionReaction': ['transcription_data'],
+     'GenericFormationReaction': [],
+     'Reaction': [],
+     'SummaryVariable': [],
+     'TranslationReaction': ['translation_data'],
+     'tRNAChargingReaction': ['tRNA_data']}
+
+_REQUIRED_PROCESS_DATA_ATTRIBUTES = {"id"}
+
+# Process data types have different attributes
+_PROCESS_DATA_TYPE_DEPENDENCIES = \
+    {'StoichiometricData': ['_stoichiometry', 'lower_bound', 'upper_bound',
+                            'subreactions'],
+
+     'ComplexData': ['stoichiometry', 'complex_id', 'modifications'],
+
+     'TranscriptionData': ['modifications', 'subreactions',
+                           'nucleotide_sequence', 'RNA_products',
+                           'RNA_polymerase', 'rho_dependent'],
+
+     'TranslationData': ['modifications', 'subreactions',
+                         'nucleotide_sequence', 'mRNA', 'protein'],
+
+     'tRNAData': ['modifications', 'codon', 'RNA', 'amino_acid',
+                  'synthetase', 'synthetase_keff'],
+
+     'TranslocationData': ['enzyme_dict', 'stoichiometry', 'keff',
+                           'length_dependent_energy'],
+
+     'PostTranslationData': ['processed_protein_id', 'unprocessed_protein_id',
+                             'propensity_scaling', 'aggregation_propensity',
+                             'translocation', 'modifications', 'subreactions',
+                             'surface_area', 'keq_folding', 'k_folding'],
+
+     'ModificationData': ['stoichiometry', 'enzyme', 'keff'],
+
+     'SubreactionData': ['stoichiometry', 'enzyme', 'keff'],
+
+     'GenericData': ['component_list']
+     }
+
+_REQUIRED_METABOLITE_ATTRIBUTES = {"id", "name", "formula"}
+
+_OPTIONAL_METABOLITE_ATTRIBUTES = {"charge", "formula", "compartment",
+                                   "_bound", "_constraint_sense"}
+
+# Some metabolite types require additional attributes
+_METABOLITE_TYPE_DEPENDENCIES = \
+    {'TranscribedGene': ['left_pos', 'right_pos', 'strand', 'RNA_type',
+                         'nucleotide_sequence'],
+     'ProcessedProtein': ['unprocessed_protein_id']
+     }
+
+
+def get_schema():
+    with open(os.path.join(cur_dir, 'JSONSCHEMA'), 'r') as f:
+        return json.load(f)
+
+
+def get_process_data_class(name):
+    # Map name in model dictlist to process data class name
+    dictlist_to_class = {'stoichiometric_data': 'StoichiometricData',
+                         'complex_data': 'ComplexData',
+                         'transcription_data': 'TranscriptionData',
+                         'translation_data': 'TranslationData',
+                         'tRNA_data': 'tRNAData',
+                         'translocation_data': 'TranslocationData',
+                         'posttranslation_data': 'PostTranslationData',
+                         'modification_data': 'ModificationData',
+                         'subreaction_data': 'SubreactionData',
+                         'generic_data': 'GenericData'}
+
+    try:
+        return dictlist_to_class[name]
+    except KeyError:
+        raise TypeError('Not a valid process_data dictlist')
+
+
+def _fix_type(value, kind=''):
+    """convert possible types to str, float, and bool"""
+    # Because numpy floats can not be pickled to json
+    if isinstance(value, string_types):
+        return str(value)
+    if isinstance(value, float_):
+        return float(value)
+    if isinstance(value, bool_):
+        return bool(value)
+    if isinstance(value, set):
+        return list(value)
+    if isinstance(value, Basic):
+        return str(value)
+    if hasattr(value, 'id'):
+        return str(value.id)
+    #if value is None:
+    #    return ''
+    return value
+
+
+def _reaction_to_dict(reaction):
+    new_reaction = {key: _fix_type(getattr(reaction, key), 'reaction')
+                    for key in _REQUIRED_REACTION_ATTRIBUTES
+                    if key != 'metabolites'}
+
+    reaction_type = reaction.__class__.__name__
+    new_reaction['reaction_type'] = {}
+    new_reaction['reaction_type'][reaction_type] = {}
+
+    for attribute in _REACTION_TYPE_DEPENDENCIES.get(reaction_type, []):
+        reaction_attribute = getattr(reaction, attribute)
+
+        new_reaction['reaction_type'][reaction_type][attribute] = \
+            _fix_type(reaction_attribute)
+
+    # Add metabolites
+    new_reaction['metabolites'] = {}
+    for met, value in reaction.metabolites.items():
+        new_reaction['metabolites'][met.id] = _fix_type(value)
+
+    return new_reaction
+
+
+def _process_data_to_dict(data):
+    process_data_type = data.__class__.__name__
+
+    new_data = {key: _fix_type(getattr(data, key))
+                for key in _REQUIRED_PROCESS_DATA_ATTRIBUTES}
+
+    special_list = ['_stoichiometry', 'subreactions', 'modifications',
+                    'stoichiometry', 'enzyme_dict', 'translocation',
+                    'surface_area', 'keq_folding', 'k_folding']
+
+    for attribute in _PROCESS_DATA_TYPE_DEPENDENCIES[process_data_type]:
+        if attribute not in special_list:
+            data_attribute = getattr(data, attribute)
+
+            new_data[attribute] = _fix_type(data_attribute, 'reaction')
+
+        elif attribute == 'enzyme_dict':
+            new_data[attribute] = {}
+            for cplx, values in getattr(data, attribute).items():
+                new_data[attribute][cplx] = {}
+                for property, value in values.items():
+                    new_data[attribute][cplx][property] = _fix_type(value)
+        else:
+            new_data[attribute] = {}
+            for metabolite, coefficient in getattr(data, attribute).items():
+                new_data[attribute][metabolite] = _fix_type(coefficient)
+
+    return new_data
+
+
+def _metabolite_to_dict(metabolite):
+
+    # TODO this is incrrectly in model as transcribed gene
+    if metabolite.id == 'RNA_degradosome':
+        metabolite.left_pos = 1
+        metabolite.right_pos = 1
+        metabolite.strand = '+'
+        metabolite.RNA_type = 'mRNA'
+
+    metabolite_type = metabolite.__class__.__name__
+
+    new_metabolite = {key: _fix_type(getattr(metabolite, key))
+                      for key in _REQUIRED_METABOLITE_ATTRIBUTES}
+
+    # Som metabolites require additional information to construct working
+    # ME-model
+    new_metabolite['metabolite_type'] = {}
+    new_metabolite['metabolite_type'][metabolite_type] = {}
+    for attribute in _METABOLITE_TYPE_DEPENDENCIES.get(metabolite_type, []):
+        metabolite_attribute = getattr(metabolite, attribute)
+        new_metabolite['metabolite_type'][metabolite_type][attribute] = \
+            metabolite_attribute
+
+    return new_metabolite
+
+
+def get_attribute_array(dictlist, type):
+    if type == 'reaction':
+        return [_reaction_to_dict(reaction) for reaction in dictlist]
+    elif type == 'process_data':
+        return [_process_data_to_dict(data) for data in dictlist]
+    elif type == 'metabolite':
+        return [_metabolite_to_dict(metabolite) for metabolite in dictlist]
+    else:
+        raise TypeError('Type must be reaction, process_data or metabolite')
+
+
+def get_global_info_dict(global_info):
+    new_global_info = {}
+    for key, value in global_info.items():
+        if type(value) != dict:
+            new_global_info[key] = _fix_type(value)
+        else:
+            new_global_info[key] = value
+    return new_global_info
+
+
+def _to_dict(model):
+
+    obj = dict(
+        reactions=get_attribute_array(model.reactions, 'reaction'),
+        stoichiometric_data=get_attribute_array(model.stoichiometric_data,
+                                                'process_data'),
+        complex_data=get_attribute_array(model.complex_data, 'process_data'),
+        transcription_data=get_attribute_array(model.transcription_data,
+                                               'process_data'),
+        translation_data=get_attribute_array(model.translation_data,
+                                             'process_data'),
+        tRNA_data=get_attribute_array(model.tRNA_data, 'process_data'),
+        translocation_data=get_attribute_array(model.translocation_data,
+                                               'process_data'),
+        posttranslation_data=get_attribute_array(model.posttranslation_data,
+                                                 'process_data'),
+        modification_data=get_attribute_array(model.modification_data,
+                                              'process_data'),
+        subreaction_data=get_attribute_array(model.subreaction_data,
+                                             'process_data'),
+        generic_data=get_attribute_array(model.generic_data, 'process_data'),
+        metabolites=get_attribute_array(model.metabolites, 'metabolite'),
+        global_info=get_global_info_dict(model.global_info)
+    )
+
+    return obj
+
+
+def save_full_me_model_json(model, file_name):
+    """
+    Save a full JSON version of the ME-model. Saving/loading a model in this
+    format can then be loaded to return a ME-model identical to the one saved.
+
+    :param :class:`~cobrame.core.MEModel.MEModel` model:
+        A full ME-model
+
+    :param str or file-like object file_name:
+        Filename of the JSON output
+
+    :returns JSON-object:
+        Full JSON representation of full ME-model
+    """
+
+    should_close = False
+    if isinstance(file_name, string_types):
+        file_name = open(file_name, 'w')
+        should_close = True
+
+    json.dump(_to_dict(model), file_name)
+
+    if should_close:
+        file_name.close()
+
+
+def add_metabolite_from_dict(model, metabolite_info):
+    """
+    Builds metabolite instances defined in dictionary, then add it to the
+    ME-model being constructed.
+
+    ProcessedProteins require additional information
+    """
+
+    metabolite_type_dict = metabolite_info['metabolite_type']
+    if len(metabolite_type_dict) != 1:
+        raise Exception('Only 1 metabolite_type in valid json')
+
+    metabolite_type = list(metabolite_type_dict.keys())[0]
+
+    # ProcessedProtein types require their unprocessed protein id as well
+    if metabolite_type != 'ProcessedProtein':
+        metabolite_obj = \
+            getattr(cobrame, metabolite_type)(metabolite_info['id'])
+    else:
+        unprocessed_id = \
+            metabolite_type_dict['ProcessedProtein']['unprocessed_protein_id']
+        metabolite_obj = \
+            getattr(cobrame, metabolite_type)(metabolite_info['id'],
+                                              unprocessed_id)
+
+    for attribute in _REQUIRED_METABOLITE_ATTRIBUTES:
+        setattr(metabolite_obj, attribute, metabolite_info[attribute])
+
+    for attribute in _METABOLITE_TYPE_DEPENDENCIES.get(metabolite_type, []):
+        value = metabolite_type_dict[metabolite_type][attribute]
+        setattr(metabolite_obj, attribute, value)
+
+    model.add_metabolites([metabolite_obj])
+
+
+def add_process_data_from_dict(model, process_data_type, process_data_info):
+    """
+    Builds process_data instances defined in dictionary, then add it to the
+    ME-model being constructed.
+
+    Most classes of process_data only require an id and model to initiate them,
+    but TranslationData, tRNAData, PostTranslationData and GenericData require
+    additional inputs.
+
+    """
+
+    # Create process data instances. Handel certain types individually
+    id = process_data_info['id']
+    if process_data_type == 'TranslationData':
+        mRNA = process_data_info['mRNA']
+        protein = process_data_info['protein']
+        process_data = \
+            getattr(cobrame, process_data_type)(id, model, mRNA, protein)
+    elif process_data_type == 'tRNAData':
+        amino_acid = process_data_info['amino_acid']
+        RNA = process_data_info['RNA']
+        codon = process_data_info['codon']
+        process_data = \
+            getattr(cobrame, process_data_type)(id, model, amino_acid, RNA,
+                                                codon)
+    elif process_data_type == 'PostTranslationData':
+        processed_protein_id = process_data_info['processed_protein_id']
+        unprocessed_protein_id = process_data_info['unprocessed_protein_id']
+        process_data = \
+            getattr(cobrame, process_data_type)(id, model,
+                                                processed_protein_id,
+                                                unprocessed_protein_id)
+    elif process_data_type == 'GenericData':
+        component_list = process_data_info['component_list']
+        process_data = \
+            getattr(cobrame, process_data_type)(id, model, component_list)
+        # Create reaction from generic process data
+        process_data.create_reactions()
+    else:
+        process_data = getattr(cobrame, process_data_type)(id, model)
+
+    # Set all of the required attributes using information in info dictionary
+    for attribute in _REQUIRED_PROCESS_DATA_ATTRIBUTES:
+        setattr(process_data, attribute, process_data_info[attribute])
+
+    # Some attributes depend on process data type. Set those here.
+    for attribute in _PROCESS_DATA_TYPE_DEPENDENCIES.get(process_data_type,
+                                                         []):
+        value = process_data_info[attribute]
+        if type(value) != dict:
+            setattr(process_data, attribute, value)
+        else:
+            for k, v in value.items():
+                getattr(process_data, attribute)[k] = v
+
+
+def add_reaction_from_dict(model, reaction_info):
+    """
+    Builds reaction instances defined in dictionary, then add it to the
+    ME-model being constructed.
+
+    """
+    reaction_type_dict = reaction_info['reaction_type']
+
+    if len(reaction_type_dict) == 1:
+        reaction_type = list(reaction_type_dict.keys())[0]
+        reaction_obj = getattr(cobrame, reaction_type)(reaction_info['id'])
+    else:
+        raise Exception('Only 1 reaction_type in valid json')
+
+    for attribute in _REQUIRED_REACTION_ATTRIBUTES:
+        # Metabolites are added to reactions using their update function,
+        # skip setting metabolite stoichiometries here
+        if attribute == 'metabolites':
+            continue
+
+        # upper and lower bounds may contain mu values. Handle that here
+        value = reaction_info[attribute]
+        if attribute in ['upper_bound', 'lower_bound']:
+            value = get_sympy_expression(value)
+        setattr(reaction_obj, attribute, value)
+
+    # Some reactions are added to model when ME-models are initialized
+    try:
+        model.add_reaction(reaction_obj)
+    except Exception:
+        reaction_obj = model.reactions.get_by_id(reaction_obj.id)
+        if reaction_type not in ['SummaryVariable',
+                                 'GenericFormationReaction']:
+            warn('Reaction (%s) already in model' % reaction_obj.id)
+
+    # These reactions types do not have update functions and need their
+    # stoichiometries set explicitly .
+    if reaction_type in ['SummaryVariable', 'Reaction']:
+        for key, value in reaction_info['metabolites'].items():
+            reaction_obj.add_metabolites({key: get_sympy_expression(value)},
+                                         combine=False)
+
+    for attribute in _REACTION_TYPE_DEPENDENCIES.get(reaction_type, []):
+        # Spontaneous reactions do no require complex_data
+        if attribute == 'complex_data' and 'SPONT' in reaction_obj.id:
+            continue
+
+        value = reaction_type_dict[reaction_type][attribute]
+        setattr(reaction_obj, attribute, value)
+
+    if hasattr(reaction_obj, 'update'):
+        reaction_obj.update()
+
+
+def full_me_model_from_dict(obj):
+    """
+    Validate and load JSON representation of the ME-model. This will return
+    a full :class:`~cobrame.core.MEModel.MEModel` object identical to the
+    one saved.
+
+    :param str or file-like object obj:
+        JSON-serialized ME-model
+
+    :returns :class:`~cobrame.core.MEModel.MEModel`:
+        Full COBRAme ME-model
+    """
+
+    try:
+        validate(obj, get_schema())
+    except ValidationError:
+        raise Exception('Must pass valid ME-model json file')
+
+    model = cobrame.MEModel()
+
+    for k, v in iteritems(obj):
+        if k in {'id', 'name', 'global_info'}:
+            setattr(model, k, v)
+
+    for metabolite in obj['metabolites']:
+        add_metabolite_from_dict(model, metabolite)
+
+    for key in obj:
+        if 'data' in key:
+            for data in obj[key]:
+                add_process_data_from_dict(model, get_process_data_class(key),
+                                           data)
+
+    for reaction in obj['reactions']:
+        add_reaction_from_dict(model, reaction)
+
+    model.update()
+
+    return model
+
+
+def load_full_me_model_json(file_name):
+
+    with open(file_name, 'r') as f:
+        model_dict = json.load(f)
+
+    return full_me_model_from_dict(model_dict)

--- a/cobrame/tests/test_ecoli_build.py
+++ b/cobrame/tests/test_ecoli_build.py
@@ -4,7 +4,8 @@ import pytest
 
 from os.path import dirname, join, abspath
 
-from cobrame.io.jsonme import load_json_me
+from cobrame.io.jsonme import (load_json_me, save_full_me_model_json,
+                               load_full_me_model_json)
 from ecolime import build_ME_model
 from ecolime.util.ME_model_comparison import find_ME_model_difference
 
@@ -13,10 +14,19 @@ models_dir = current_dir + '/me_models/'
 
 del dirname, abspath
 
+test_model = build_ME_model.return_ME_model()
+
+
+def test_full_json_dumping():
+    save_full_me_model_json(test_model, 'test_json_dump.json')
+    model = load_full_me_model_json('test_json_dump.json')
+    difference = find_ME_model_difference(model, test_model, 1e-6)
+    print(difference)
+    assert (len(difference) == 0)
+
 
 def test_ecoli_build():
     benchmark_model = load_json_me(join(models_dir, 'iLE1678_benchmark.json'))
-    test_model = build_ME_model.return_ME_model()
     difference = find_ME_model_difference(benchmark_model, test_model, 1e-6)
     print('-----------------------Difference----------------------')
     print(difference)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(name="cobrame",
       author_email="minime_dev@googlegroups.com",
       url="https://github.com/SBRG/cobrame",
       install_requires=["sympy", "six", "Biopython", "cobra<=0.5.11", "pandas",
-                        "scipy", "numpy", "setuptools"],
+                        "scipy", "numpy", "setuptools", "jsonschema"],
+      package_data={'': ['io/JSONSCHEMA']},
       packages=find_packages()
       )

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,5 @@ deps =
     numpy
     jsonschema
 commands =
-    pip install git+https://github.com/sbrg/ecolime.git@devel
+    pip install git+https://github.com/sbrg/ecolime.git
     pytest


### PR DESCRIPTION
Save and load full JSON representations of the ME-model without losing any reaction/processdata information.

The current JSON schema will be edited some in the near future as cobrame is refactored (see Projects), but establishing this as a starting point will ease the process of porting models built using earlier cobrame versions.

Closes #3